### PR TITLE
Updated token key serialization

### DIFF
--- a/src/serialization.ts
+++ b/src/serialization.ts
@@ -40,7 +40,6 @@ export function decodeIssuerParams(ipJSON: IssuerParamsJSON): IssuerParams {
     }
     const groupParams = getEcGroup(descGq);
     const Gq = groupParams.Gq;
-    const Zq = Gq.Zq;
     // g = [g0, g1, ... gn, gt]
     const g = groupParams.g.slice(0, n); // keep only n generators
     g.unshift(Gq.getElement(fromB64(ipJSON.g0)));

--- a/src/upjf.ts
+++ b/src/upjf.ts
@@ -99,10 +99,12 @@ export interface IssuerParamsJWK {
     spec: string;
 }
 
-export function encodePrivateKeyAsBase64Url(y0: FieldZqElement): string {
-    return toBase64Url(y0.getBytes());
+// encodes Issuer parameters and U-Prove token private keys as base64url
+export function encodePrivateKeyAsBase64Url(key: FieldZqElement): string {
+    return toBase64Url(key.getBytes());
 }
 
+// decodes Issuer parameters and U-Prove token private keys from base64url
 export function decodeBase64UrlAsPrivateKey(ip: IssuerParams, b64: string): FieldZqElement {
     return ip.Gq.Zq.getElement(fromBase64Url(b64));
 }


### PR DESCRIPTION
Clarified that private key serialization works for U-Prove tokens as well; updated sample accordingly.